### PR TITLE
Possible way to forward provisioning logs to web UI

### DIFF
--- a/aws/modules/etcd/elb.tf
+++ b/aws/modules/etcd/elb.tf
@@ -1,5 +1,5 @@
 resource "aws_elb" "external" {
-  name = "kz8s-apiserver-${replace(var.name, "/(.{0,17})(.*)/", "$1")}"
+  name = "k8pi-${replace(var.name, "/(.{0,27})(.*)/", "$1")}"
 
   cross_zone_load_balancing = false
 

--- a/packet/input.tf
+++ b/packet/input.tf
@@ -4,7 +4,7 @@ variable "name" { default = "packet" }
 variable "packet_project_id" {} # required for now
 variable "packet_api_key" {}
 # https://www.packet.net/locations/
-variable "packet_facility" { default = "sjc1" }
+variable "packet_facility" { default = "ewr1" }
 variable "packet_billing_cycle" { default = "hourly" }
 variable "packet_operating_system" { default = "coreos_stable" }
 variable "packet_master_device_plan" { default = "baremetal_0" }


### PR DESCRIPTION
I'm sure this is not the right branch but just as an example:

The cncfdemo now makes *zero* assumptions about environments or programming languages. 
These are the lowest common denominator steps: 

1) Provisioning Cloud Resources
2) Instances Booting
3) Helm Chart Install

Since cross-cloud is a dockerized bash script wrapper of terraform, the most painless way I could think of is to simply wrap these steps in the script into logical groupings (bash curly braces).

Step names are unique and need to start with a number, the hyphens get replaced with spaces.
Simply tee the stdout of the command grouping to the endpoint and the backend will flow it out to the UI.

>  endpoint=https://endpoint_url
> dID=$(cat demoId)
> echo $dID

> step='01-Creating-Cloud-Resources'
> {
>   terraform init
>   time terraform apply
>   anything else
> } 2>&1 | tee /tmp/${step}
> curl -s --output /dev/null --request POST --include --data-binary @/tmp/${step} --no-buffer ${endpoint}/${dID}/${step}