### PR TITLE
Make the copying of template directories explicit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,13 +91,13 @@ COPY provision.sh /cncf/
 COPY s3-backend.tf /cncf/
 COPY file-backend.tf /cncf/
 
-COPY master_templates-v1.7.2 /cncf/
-COPY master_templates-v1.8.1 /cncf/
-COPY master_templates-v1.9.0-alpha.1 /cncf/
+COPY master_templates-v1.7.2/ /cncf/master_templates-v1.7.2/
+COPY master_templates-v1.8.1/ /cncf/master_templates-v1.8.1/
+COPY master_templates-v1.9.0-alpha.1/ /cncf/master_templates-v1.9.0-alpha.1/
 
-COPY worker_templates-v1.7.2 /cncf/
-COPY worker_templates-v1.8.1 /cncf/
-COPY worker_templates-v1.9.0-alpha.1 /cncf/
+COPY worker_templates-v1.7.2/ /cncf/worker_templates-v1.7.2/
+COPY worker_templates-v1.8.1/ /cncf/worker_templates-v1.8.1/
+COPY worker_templates-v1.9.0-alpha.1/ /cncf/worker_templates-v1.9.0-alpha.1/
 
 RUN chmod +x /cncf/provision.sh
 WORKDIR /cncf/


### PR DESCRIPTION
Updates the Dockerfile to make the copying of the master
and worker template directories explicit. For recent versions
of Docker, the copy operation can fail with an error.

For example, https://github.com/moby/moby/issues/33974